### PR TITLE
Add Cost Calculator Mode for TCO comparison

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "programming-advisor",
       "source": "./",
       "description": "Build vs Buy advisor that searches for existing solutions before vibe coding. Prevents reinventing the wheel.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "gaupoit"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "programming-advisor",
   "description": "Build vs Buy advisor that searches for existing solutions before vibe coding. Prevents reinventing the wheel by finding libraries, open source tools, and SaaS alternatives.",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "gaupoit",
     "email": "hello@devbanhmi.com"

--- a/skills/programming-advisor/SKILL.md
+++ b/skills/programming-advisor/SKILL.md
@@ -4,8 +4,9 @@ description: >
   Anti-reinventing-the-wheel advisor that helps users evaluate build vs buy decisions before vibe coding.
   Use when users describe something they want to build, create, or develop - especially features, tools,
   apps, scripts, or systems. Searches for existing solutions, estimates vibe coding costs (tokens, time,
-  complexity), and presents comparison tables to enable informed decisions. When user accepts a recommendation,
-  provides complete integration planning with install commands, starter code, and project-specific guidance.
+  complexity), and presents comparison tables to enable informed decisions. Includes total cost of ownership
+  analysis comparing Year 1 vs Year 3 costs for SaaS vs DIY. When user accepts a recommendation, provides
+  complete integration planning with install commands, starter code, and project-specific guidance.
   Triggers on: "I want to build...", "Help me create...", "Can you code...", "I need a [tool/app/script]...",
   project planning, feature requests, or any coding task that might have existing solutions.
 ---
@@ -148,6 +149,66 @@ Flag any concerns:
 - **Peer dependencies**: "You'll also need to install X"
 - **Config requirements**: "Requires adding to your tsconfig/babel/webpack config"
 
+### Step 8: Cost Analysis (For Significant Decisions)
+
+For features with meaningful cost implications (auth, payments, email, infrastructure), provide a Total Cost of Ownership (TCO) comparison.
+
+#### 8.1 When to Include Cost Analysis
+
+Include cost table when:
+- SaaS options have monthly fees > $10
+- DIY token estimate > 50K tokens
+- User asks about costs or "is it worth it"
+- Comparing multiple paid services
+- Security-sensitive features (auth, payments)
+
+#### 8.2 Cost Calculation
+
+Use the pricing reference: [references/pricing-data.md](references/pricing-data.md)
+
+**Formula:**
+```
+Year N Cost = Setup Cost + (Monthly × 12 × N) + (Maintenance × N)
+
+Where:
+- Setup Cost (DIY) = Token Estimate × $0.015/1K tokens
+- Maintenance (DIY) = 20% of Setup Cost annually
+- Maintenance (SaaS) = $0
+```
+
+#### 8.3 Cost Table Format
+
+```markdown
+## 💰 Cost Analysis
+
+| Option | Setup | Monthly | Year 1 | Year 3 | Notes |
+|--------|-------|---------|--------|--------|-------|
+| [SaaS A] | 10min | $25 | $300 | $900 | Free tier: 10K MAU |
+| [SaaS B] | 15min | $35 | $420 | $1,260 | More features |
+| [Free/OSS] | 1hr | $0 | $0 | $0 | Self-host required |
+| DIY | Xhrs | $0 | ~$Y | ~$Z | + maintenance burden |
+
+💡 **Break-even:** [When DIY becomes cheaper, if ever]
+⚠️ **Hidden costs:** [Security audits, compliance, on-call burden]
+```
+
+#### 8.4 Hidden Costs to Surface
+
+Always mention relevant hidden costs:
+- **Security audits**: $5K-50K for custom auth systems
+- **Compliance**: SOC2, GDPR, PCI implementation time
+- **On-call burden**: DIY = you're the support team
+- **Opportunity cost**: Time not spent on core product
+- **Technical debt**: Custom code needs maintenance forever
+
+#### 8.5 Red Flags to Call Out
+
+Warn users when they say:
+- "It's just a simple auth system" → Auth is never simple
+- "We can build it in a weekend" → You can't, securely
+- "We'll add security later" → Security debt is expensive
+- "It's cheaper long-term" → Usually false under 10K users
+
 ## Response Template
 
 ```
@@ -169,6 +230,15 @@ I found [N] existing solutions before we write custom code:
 | Option | Type | Cost | Setup | Maintenance | Est. Tokens |
 |--------|------|------|-------|-------------|-------------|
 | ... | ... | ... | ... | ... | ... |
+
+## 💰 Cost Analysis (for significant decisions)
+
+| Option | Setup | Monthly | Year 1 | Year 3 | Notes |
+|--------|-------|---------|--------|--------|-------|
+| ... | ... | ... | ... | ... | ... |
+
+💡 **Break-even:** [analysis]
+⚠️ **Hidden costs:** [security, compliance, maintenance]
 
 ## 💡 Recommendation
 
@@ -254,3 +324,5 @@ See [references/token-estimates.md](references/token-estimates.md) for detailed 
 See [references/common-solutions.md](references/common-solutions.md) for exhaustive list of commonly reinvented wheels.
 
 See [references/integration-patterns.md](references/integration-patterns.md) for project detection and starter code patterns.
+
+See [references/pricing-data.md](references/pricing-data.md) for SaaS pricing and cost calculation data.

--- a/skills/programming-advisor/references/pricing-data.md
+++ b/skills/programming-advisor/references/pricing-data.md
@@ -1,0 +1,182 @@
+# Pricing Data Reference
+
+Use this data to calculate total cost of ownership comparisons. Prices as of 2024.
+
+## Cost Calculation Formula
+
+```
+Year N Cost = Setup Cost + (Monthly × 12 × N) + (Maintenance × N)
+
+Where:
+- Setup Cost (DIY) = Token Estimate × $0.015/1K tokens (blended rate)
+- Maintenance (DIY) = 20% of Setup Cost annually
+- Maintenance (SaaS) = $0 (handled by provider)
+```
+
+## Token Cost Estimates
+
+| Model | Input (1K tokens) | Output (1K tokens) | Blended Estimate |
+|-------|-------------------|--------------------| -----------------|
+| Claude Sonnet | $0.003 | $0.015 | ~$0.015/1K |
+| Claude Opus | $0.015 | $0.075 | ~$0.06/1K |
+| GPT-4 | $0.01 | $0.03 | ~$0.025/1K |
+
+**Rule of thumb:** Estimate $0.015/1K tokens for typical Claude Code usage.
+
+---
+
+## Authentication & Identity
+
+| Service | Free Tier | Starter | Pro | Enterprise |
+|---------|-----------|---------|-----|------------|
+| **Auth0** | 7,500 MAU | $35/mo (500 MAU) | $240/mo | Custom |
+| **Clerk** | 10,000 MAU | $25/mo | $99/mo | Custom |
+| **Supabase Auth** | 50,000 MAU | Free w/ Supabase | - | - |
+| **Firebase Auth** | Unlimited | Free | Free | Free |
+| **WorkOS** | 1M MAU | Free | Enterprise | Custom |
+| **Kinde** | 10,500 MAU | $25/mo | $99/mo | Custom |
+
+**DIY Estimate:** 80-150K tokens (~$1.2K-$2.3K setup), 20% annual maintenance
+
+---
+
+## Email Services
+
+| Service | Free Tier | Starter | Growth |
+|---------|-----------|---------|--------|
+| **Resend** | 3,000/mo | $20/mo (50K) | $80/mo (200K) |
+| **SendGrid** | 100/day | $20/mo (50K) | $50/mo (100K) |
+| **Postmark** | 100/mo | $15/mo (10K) | $50/mo (50K) |
+| **AWS SES** | 62K/mo (w/ EC2) | $0.10/1K | $0.10/1K |
+| **Mailgun** | 5,000/mo (3 mo) | $35/mo (50K) | $80/mo (100K) |
+
+**DIY Estimate:** 15-30K tokens (~$225-$450 setup), SMTP config complexity
+
+---
+
+## Payments & Billing
+
+| Service | Transaction Fee | Monthly | Notes |
+|---------|-----------------|---------|-------|
+| **Stripe** | 2.9% + $0.30 | $0 | Industry standard |
+| **Paddle** | 5% + $0.50 | $0 | Handles tax/compliance |
+| **LemonSqueezy** | 5% + $0.50 | $0 | Merchant of record |
+| **PayPal** | 2.9% + $0.30 | $0 | Consumer familiarity |
+
+**DIY Estimate:** Don't. PCI compliance alone costs $50K+/year.
+
+---
+
+## Database & Backend
+
+| Service | Free Tier | Starter | Pro |
+|---------|-----------|---------|-----|
+| **Supabase** | 500MB, 2 projects | $25/mo | $599/mo |
+| **PlanetScale** | 5GB, 1B reads | $39/mo | $99/mo |
+| **Neon** | 512MB | $19/mo | $69/mo |
+| **Railway** | $5 credit | Pay-as-you-go | ~$20/mo typical |
+| **Vercel Postgres** | 256MB | $20/mo | Included in Pro |
+
+**DIY (self-hosted):** VPS $5-20/mo + maintenance time
+
+---
+
+## File Storage & CDN
+
+| Service | Free Tier | Starter | Notes |
+|---------|-----------|---------|-------|
+| **Cloudflare R2** | 10GB + 10M requests | $0.015/GB | No egress fees |
+| **AWS S3** | 5GB (12 mo) | $0.023/GB | + egress costs |
+| **Uploadthing** | 2GB | $10/mo (100GB) | Dev-friendly |
+| **Cloudinary** | 25GB | $99/mo | Image transforms |
+
+---
+
+## Search
+
+| Service | Free Tier | Starter | Notes |
+|---------|-----------|---------|-------|
+| **Algolia** | 10K records | $1/1K records | Fast, expensive at scale |
+| **Typesense** | Self-host | $29/mo cloud | Open source |
+| **Meilisearch** | Self-host | $30/mo cloud | Easy setup |
+| **Elasticsearch** | Self-host | $95/mo cloud | Enterprise features |
+
+**DIY (pg_trgm):** Free with PostgreSQL, good enough for most apps
+
+---
+
+## Monitoring & Error Tracking
+
+| Service | Free Tier | Starter | Team |
+|---------|-----------|---------|------|
+| **Sentry** | 5K errors/mo | $26/mo | $80/mo |
+| **LogRocket** | 1K sessions/mo | $99/mo | $250/mo |
+| **Datadog** | 14-day trial | $15/host/mo | + features |
+| **Better Stack** | 1 user | $24/mo | $85/mo |
+
+---
+
+## Analytics
+
+| Service | Free Tier | Starter | Notes |
+|---------|-----------|---------|-------|
+| **Plausible** | 30-day trial | $9/mo (10K) | Privacy-focused |
+| **Fathom** | - | $14/mo (100K) | Privacy-focused |
+| **PostHog** | 1M events/mo | $0/mo | Product analytics |
+| **Mixpanel** | 20M events/mo | $20/mo | Event tracking |
+| **Google Analytics** | Unlimited | Free | Privacy concerns |
+
+---
+
+## AI & LLM Integration
+
+| Service | Free Tier | Cost | Notes |
+|---------|-----------|------|-------|
+| **OpenAI API** | - | Pay-per-token | GPT-4, embeddings |
+| **Anthropic API** | - | Pay-per-token | Claude models |
+| **Vercel AI SDK** | - | Free (BYO keys) | React hooks |
+| **LangChain** | - | Free (BYO keys) | Orchestration |
+| **Pinecone** | 100K vectors | $70/mo | Vector DB |
+| **Weaviate** | Self-host | $25/mo cloud | Vector DB |
+
+---
+
+## Cron & Background Jobs
+
+| Service | Free Tier | Starter | Notes |
+|---------|-----------|---------|-------|
+| **Inngest** | 50K runs/mo | $50/mo | Event-driven |
+| **Trigger.dev** | 10K runs/mo | $30/mo | Background jobs |
+| **Quirrel** | Open source | Self-host | Simple cron |
+| **Vercel Cron** | Included | With Vercel | Basic cron |
+
+**DIY (node-cron):** Free, but needs always-on server
+
+---
+
+## Break-Even Analysis Guidelines
+
+### When DIY Makes Sense
+
+| Scenario | Break-even Point |
+|----------|------------------|
+| Auth (simple) | >100K MAU or custom requirements |
+| Email (transactional) | >500K emails/mo |
+| Search | >1M records or real-time requirements |
+| Payments | Never (compliance costs too high) |
+| Analytics | Privacy requirements or >10M events |
+
+### Hidden Costs to Surface
+
+1. **Security audits** - $5K-50K for custom auth
+2. **Compliance** - SOC2, GDPR implementation time
+3. **On-call burden** - DIY = you're the support
+4. **Opportunity cost** - Time not spent on core product
+5. **Technical debt** - Custom code needs maintenance forever
+
+### Red Flags for DIY
+
+- "It's just a simple [auth/payment/email] system"
+- "We can build it in a weekend"
+- "We'll add security later"
+- "It's cheaper long-term" (usually false under 10K users)


### PR DESCRIPTION
## Summary

Implements the Cost Calculator feature requested in #3. Adds total cost of ownership (TCO) analysis to help users make informed build vs buy decisions.

### New Capabilities

- **Year 1 vs Year 3 cost tables** - Compare SaaS monthly fees vs DIY token costs
- **Break-even analysis** - Shows when DIY becomes cheaper (if ever)
- **Hidden costs surfacing** - Security audits, compliance, on-call burden
- **Red flag warnings** - Catches "we can build it in a weekend" thinking

### Example Output

```
## 💰 Cost Analysis: Authentication

| Option | Setup | Monthly | Year 1 | Year 3 | Notes |
|--------|-------|---------|--------|--------|-------|
| Auth0 | 10min | $35 | $420 | $1,260 | Free tier: 7.5K MAU |
| Clerk | 10min | $25 | $300 | $900 | Free tier: 10K MAU |
| Supabase | 15min | $0 | $0 | $0 | Free w/ Supabase |
| DIY | 8hrs | $0 | ~$1,500 | ~$2,100 | + maintenance |

💡 Break-even: DIY only cheaper at >100K MAU
⚠️ Hidden costs: Security audits ($5-50K), compliance, on-call burden
```

### Changes

| File | Change |
|------|--------|
| `SKILL.md` | Added Step 8: Cost Analysis with 5 sub-sections |
| `SKILL.md` | Updated response template with cost table |
| `references/pricing-data.md` | New file with SaaS pricing, cost formulas |
| `plugin.json` | Version bump to 1.2.0 |
| `marketplace.json` | Version bump to 1.2.0 |

### Pricing Data Included

- Authentication (Auth0, Clerk, Supabase, Firebase, WorkOS)
- Email (Resend, SendGrid, Postmark, AWS SES)
- Payments (Stripe, Paddle, LemonSqueezy)
- Database (Supabase, PlanetScale, Neon, Railway)
- Storage (Cloudflare R2, AWS S3, Uploadthing)
- Search (Algolia, Typesense, Meilisearch)
- Monitoring (Sentry, LogRocket, Datadog)
- Analytics (Plausible, PostHog, Mixpanel)

## Test plan

- [ ] Test cost table appears for auth-related requests
- [ ] Verify Year 1/Year 3 calculations are reasonable
- [ ] Check break-even analysis makes sense
- [ ] Confirm hidden costs are surfaced appropriately

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)