### PR TITLE
Fix skill description format for auto-triggering

### DIFF
--- a/skills/programming-advisor/SKILL.md
+++ b/skills/programming-advisor/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: programming-advisor
-description: >
-  Anti-reinventing-the-wheel advisor that helps users evaluate build vs buy decisions before vibe coding.
-  Use when users describe something they want to build, create, or develop - especially features, tools,
-  apps, scripts, or systems. Searches for existing solutions, estimates vibe coding costs (tokens, time,
-  complexity), and presents comparison tables to enable informed decisions. Includes total cost of ownership
-  analysis comparing Year 1 vs Year 3 costs for SaaS vs DIY. When user accepts a recommendation, provides
-  complete integration planning with install commands, starter code, and project-specific guidance.
-  Triggers on: "I want to build...", "Help me create...", "Can you code...", "I need a [tool/app/script]...",
-  project planning, feature requests, or any coding task that might have existing solutions.
+description: "Build vs Buy advisor. Use when users say: 'I want to build...', 'Help me create...', 'Can you code...', 'I need a tool/app/script'. Searches for existing libraries, SaaS, and open source solutions before vibe coding. Estimates token costs and provides comparison tables."
 ---
 
 # Programming Advisor - "Reinventing the Wheel" Detector


### PR DESCRIPTION
## Summary
- Fix SKILL.md description format from multiline YAML folded block (`>`) to single-line quoted string
- The multiline format was not being parsed correctly by Claude Code
- This was causing the skill description to appear empty, preventing auto-triggering

## Problem
When users typed trigger phrases like "I want to build..." the skill wasn't auto-invoking because Claude couldn't see the description.

## Solution
Changed from:
```yaml
description: >
  Anti-reinventing-the-wheel advisor...
  (multiline)
```

To:
```yaml
description: "Build vs Buy advisor. Use when users say: 'I want to build...', ..."
```

## Test plan
- [x] Clear plugin cache: `rm -rf ~/.claude/plugins/cache/devbanhmi-marketplace/programming-advisor`
- [x] Restart Claude Code
- [x] Test trigger phrase: "I want to build a CSV editor"
- [x] Verify skill auto-invokes

🤖 Generated with [Claude Code](https://claude.com/claude-code)